### PR TITLE
Adds legacy endpoint support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,76 @@ This will fire off a request that looks something like this:
 </request>
 ```
 
+### Legacy Endpoints
+
+The Intacct team has deprecated a number of endpoints which are now only accessible via the legacy API. This API has a different expectation on XML body syntax as well as parameter order enforcement via XSD. The process to construct a legacy request is similar to a standard request, just using the `LegacyRequest` class.
+
+```ruby
+request = IntacctRuby::LegacyRequest.new(REQUEST_OPTS)
+
+request.create object_type: :record_cctransaction, parameters: {
+  chargecardid: '1',
+  paymentdate: { year: 2019, month: 11, day: 11 },
+  ccpayitems: [
+    cpayitem: {
+      glaccountno: 1234,
+      paymentamount: '0.99',
+      locationid: 1,
+    }
+  ]
+}
+
+request.create object_type: :reverse_cctransaction, parameters: {
+  key: '4321',
+  datereversed: { year: 2019, month: 11, day: 11 },
+  memo: 'Purchase returned for refund'
+}
+
+request.send
+```
+
+The legacy request class will generate XML that looks something like this.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<request>
+   <control><!-- Authentication Params --></control>
+   <operation transaction="true">
+      <authentication><!-- Authentication Params --></authentication>
+      <content>
+         <function controlid="create-record_cctransaction-2019-06-30 16:45:12 UTC">
+            <record_cctransaction>
+               <chargecardid>1</chargecardid>
+               <paymentdate>
+                  <year>2019</year>
+                  <month>11</month>
+                  <day>11</day>
+               </paymentdate>
+               <ccpayitems>
+                  <ccpayitem>
+                     <glaccountno>1234</glaccountno>,
+                     <paymentamount>'0.99'</paymentamount>
+                     <locationid>1</locationid>
+                  </ccpayitem>
+               </ccpayitems>
+            </record_cctransaction>
+         </function>
+         <function controlid="create-reverse_cctransaction-2019-06-30 16:45:12 UTC">
+            <reverse_cctransaction>
+               <key>4321</key>
+               <datereversed>
+                  <year>2019</year>
+                  <month>11</month>
+                  <day>11</day>
+               </datereversed>
+               <memo>Purchase returned for refund</memo>
+            </reverse_cctransaction>
+         </function>
+      </content>
+   </operation>
+</request>
+```
+
 ### Read Requests
 
 The read requests follow a slightly different pattern. The object-type is mentioned inside the `object` tag as seen here [Intacct List Journal Entries](https://developer.intacct.com/api/general-ledger/journal-entries/#list-journal-entry-lines).  Hence, read requests don't accept a `object_type:` argument directly, the object type is passed through the parameters argument. The following code will read all GLENTRY objects in a specific interval
@@ -92,7 +162,7 @@ The read requests follow a slightly different pattern. The object-type is mentio
 ```ruby
 request = IntacctRuby::Request.new(REQUEST_OPTS)
 
-# Object-Type GLENTRY is sent through the parameters arguments 
+# Object-Type GLENTRY is sent through the parameters arguments
 request.readByQuery parameters: {
   object: 'GLENTRY',
   query: "BATCH_DATE >= '03-01-2018' AND BATCH_DATE <= '03-15-2018'",

--- a/lib/intacct_ruby.rb
+++ b/lib/intacct_ruby.rb
@@ -3,3 +3,4 @@ require 'intacct_ruby/version'
 
 require 'intacct_ruby/request'
 require 'intacct_ruby/response'
+require 'intacct_ruby/legacy_request'

--- a/lib/intacct_ruby/legacy_function.rb
+++ b/lib/intacct_ruby/legacy_function.rb
@@ -1,0 +1,16 @@
+module IntacctRuby
+  class LegacyFunction < Function
+
+    def to_xml
+      xml = Builder::XmlMarkup.new
+
+      xml.function controlid: controlid do
+        xml.tag! @object_type do
+          xml << parameter_xml(@parameters)
+        end
+      end
+
+      xml.target!
+    end
+  end
+end

--- a/lib/intacct_ruby/legacy_request.rb
+++ b/lib/intacct_ruby/legacy_request.rb
@@ -1,0 +1,13 @@
+require 'intacct_ruby/legacy_function'
+
+module IntacctRuby
+  class LegacyRequest < Request
+
+    private
+
+    def method_missing(method_name, *arguments, &block)
+      super unless LegacyFunction::ALLOWED_TYPES.include? method_name.to_s
+      @functions << LegacyFunction.new(method_name, arguments.shift, *arguments)
+    end
+  end
+end

--- a/spec/legacy_function_spec.rb
+++ b/spec/legacy_function_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+require 'mocha/api'
+require 'nokogiri'
+
+require 'intacct_ruby/legacy_function'
+require 'intacct_ruby/exceptions/unknown_function_type'
+
+include IntacctRuby
+
+def to_xml_key(symbol)
+  symbol.to_s
+end
+
+describe LegacyFunction do
+  describe :initialize do
+    context 'given a valid function type' do
+      it 'creates a function without error' do
+        type = LegacyFunction::ALLOWED_TYPES.first
+
+        expect { LegacyFunction.new(type, object_type: :objecttype, parameters: {some: 'parameter'}) }
+          .not_to raise_error
+      end
+    end
+
+    context 'given an invalid function type' do
+      it 'raises an error' do
+        expect { LegacyFunction.new(:badtype, object_type: :objecttype, parameters: {some: 'parameter'}) }
+          .to raise_error Exceptions::UnknownFunctionType
+      end
+    end
+  end
+
+  describe :to_xml do
+    let(:function_type) { :create }
+    let(:object_type)   { :record_cctransaction }
+    let(:parameters) do
+      {
+        some:           'parameter',
+        another:        'string',
+        risky:          'risky&><parameter',
+        nested_as_hash:         { nested_key: 'nested > value' },
+        another_nested_as_hash: { another_key: 'another < value' },
+        nested_as_array: [
+          { first_key:  'first_value <'  },
+          { second_key: 'second_value >' }
+        ]
+      }
+    end
+
+    let(:function)      { LegacyFunction.new(function_type, object_type: object_type, parameters: parameters) }
+    let(:xml)           { Nokogiri::XML function.to_xml }
+
+    it 'has a controlid' do
+      xml_controlid = xml.xpath('function').first.attributes['controlid'].value
+
+      expect(xml_controlid)
+        .to include function_type.to_s, object_type.to_s
+    end
+
+    it 'has an object type with proper formatting' do
+      expect(xml.xpath('function').children.first.name)
+        .to eq object_type.to_s
+    end
+
+    context 'given non-nested parameters' do
+      it 'has function parameters as key/value pairs' do
+        parameters.select { |_, value| [String, Integer].include?(value.class) }
+                 .each do |key, expected_value|
+          xml_object_key = to_xml_key object_type
+          xml_parameter_key = to_xml_key key
+
+          xml_parameter_value = xml.xpath(
+            "//#{xml_object_key}/#{xml_parameter_key}"
+          )
+
+          expect(xml_parameter_value.first.children.to_s)
+            .to eq expected_value.encode(xml: :text)
+        end
+      end
+    end
+
+    context 'given nested parameters' do
+      context 'given that nested parameters are in hash' do
+        it 'converts those parameters to nested XML' do
+          parameters.select { |_, value| value.is_a? Hash }
+                   .each do |key, nested_value|
+            xml_object_key = to_xml_key object_type
+            xml_outer_key = to_xml_key key
+
+            nested_value.each do |inner_key, inner_value|
+              xml_inner_key = to_xml_key inner_key
+              xml_inner_value = xml.xpath(
+                "//#{xml_object_key}/#{xml_outer_key}/#{xml_inner_key}"
+              )
+
+              expect(xml_inner_value.first.children.to_s)
+                .to eq inner_value.encode(xml: :text)
+            end
+          end
+        end
+      end
+
+      context 'given that those parameters are in an array' do
+        it 'converts those parameters to an XML list' do
+          parameters.select { |_, value| value.is_a? Array }
+                   .each do |outer_key, array_body|
+            xml_object_key = to_xml_key object_type
+            xml_array_key = to_xml_key outer_key # key of XML Array
+            array_body.each do |hash_entry| # because array of hashes
+              hash_entry.each do |array_item_key, array_item_value|
+                xml_array_item_key = to_xml_key array_item_key
+                xml_array_item_value = xml.xpath(
+                  "//#{xml_object_key}/#{xml_array_key}/#{xml_array_item_key}"
+                )
+
+                expect(xml_array_item_value.first.children.to_s)
+                  .to eq array_item_value.encode(xml: :text)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/legacy_request_spec.rb
+++ b/spec/legacy_request_spec.rb
@@ -1,0 +1,232 @@
+require 'spec_helper'
+require 'mocha/api'
+require 'nokogiri'
+
+require 'intacct_ruby/request'
+require 'intacct_ruby/function'
+require 'intacct_ruby/response'
+require 'intacct_ruby/legacy_request'
+require 'intacct_ruby/exceptions/insufficient_credentials_exception'
+require 'intacct_ruby/exceptions/empty_request_exception'
+
+include IntacctRuby
+
+# For all ENVs in this format:
+# xml_key represents the key associated with each ENV in the request produced
+AUTHENTICATION_PARAMS = {
+  senderid: 'senderid_value',
+  sender_password: 'sender_password_value',
+  userid: 'userid_value',
+  companyid: 'companyid_value',
+  user_password: 'user_password_value'
+}.freeze
+
+def generate_request_xml(request_param_overrides = {})
+  @request_xml ||= begin
+    Nokogiri::XML LegacyRequest.new(
+      *function_stubs,
+      AUTHENTICATION_PARAMS.merge(request_param_overrides)
+    ).to_xml
+  end
+end
+
+def control_block_xml
+  @control_block_xml ||= @request_xml.xpath('/request/control')
+end
+
+def operation_block_xml
+  @operation_block_xml ||= @request_xml.xpath('/request/operation')
+end
+
+def get_value_from(xml, node_name)
+  xml.xpath(node_name).text
+end
+
+def function_stubs
+  @function_stubs ||= %i(function_a function_b).map do |function|
+    mock do
+      stubs(:to_xml).returns("[#{function}]")
+    end
+  end
+end
+
+describe LegacyRequest do
+  describe :send do
+    it 'sends request through the API' do
+      request = LegacyRequest.new(*function_stubs, AUTHENTICATION_PARAMS)
+      response = mock('IntacctRuby::Response')
+
+      api_spy = mock('IntacctRuby::Api')
+      api_spy.expects(:send_request).with(request).returns(response)
+
+      Response.expects(:new).with(response)
+
+      request.send(api: api_spy)
+    end
+
+    it 'raises error unless all authentication keys are provided' do
+      AUTHENTICATION_PARAMS.keys.each do |omitted_key|
+        incomplete_params = AUTHENTICATION_PARAMS.dup
+        incomplete_params.delete(omitted_key)
+
+        request = LegacyRequest.new(*function_stubs, incomplete_params)
+
+        expected_error = Exceptions::InsufficientCredentialsException
+        expected_message = Regexp.new(
+          "\\[:#{omitted_key}\\] required for a valid request."
+        )
+
+        expect { request.send }
+          .to raise_error(expected_error, expected_message)
+      end
+    end
+
+    it 'raises an error if no functions are provided' do
+      request = LegacyRequest.new(*[], AUTHENTICATION_PARAMS)
+
+      expect { request.send }
+        .to raise_error(Exceptions::EmptyRequestException)
+    end
+
+    it 'behaves like Object#send if a symbol is provided' do
+      request = LegacyRequest.new(*function_stubs, AUTHENTICATION_PARAMS)
+
+      expect(request.send(:to_xml))
+        .to eq request.to_xml
+    end
+
+    describe 'control block' do
+      it 'contains expected authentication parameters' do
+        generate_request_xml
+
+        {
+          senderid: 'senderid',
+          sender_password: 'password'
+        }.each do |parameter_name, xml_label|
+          expected = AUTHENTICATION_PARAMS[parameter_name]
+          actual = get_value_from control_block_xml, xml_label
+
+          expect(actual).to eq expected
+        end
+      end
+
+      it 'contains valid controlid' do
+        generate_request_xml
+
+        controlid = get_value_from control_block_xml, 'controlid'
+
+        # if controlid is not a valid datetime string, this will blow up
+        expect { DateTime.parse(controlid) }.not_to raise_error
+      end
+    end
+
+    describe 'authentication block' do
+      it 'contains expected authentication parameters' do
+        generate_request_xml
+
+        authentication_block_xml = @request_xml.xpath(
+          '/request/operation/authentication/login'
+        )
+
+        {
+          userid: 'userid',
+          user_password: 'password',
+          companyid: 'companyid'
+        }.each do |parameter_name, xml_label|
+          expected = AUTHENTICATION_PARAMS[parameter_name]
+          actual = get_value_from authentication_block_xml, xml_label
+
+          expect(actual).to eq expected
+        end
+      end
+    end
+
+    describe 'content block' do
+      context 'using legacy function objects' do
+        it 'contains function payloads' do
+          generate_request_xml
+
+          content_block = operation_block_xml.xpath('content').text
+          function_stubs.each do |function|
+            expect(content_block).to include function.to_xml
+          end
+        end
+      end
+
+      context 'using dynamic function generation' do
+        let(:object_type) { :object_type }
+        let(:function_type) { :create }
+        let(:parameters) { { parameter_1: 'value_1', parameter_2: 'value_2' } }
+        let(:request_xml) do
+          request = LegacyRequest.new(AUTHENTICATION_PARAMS)
+          request.public_send(function_type, object_type: object_type, parameters: parameters)
+
+          Nokogiri:: XML request.to_xml
+        end
+
+        it 'contains expected function xml' do
+          expected_function = LegacyFunction.new function_type, object_type: object_type, parameters: parameters
+          expected_function_xml = Nokogiri::XML(expected_function.to_xml)
+                                          .xpath('function') # strips xml header
+
+          expect(request_xml.xpath('//content/function').to_s)
+            .to include expected_function_xml.to_s
+        end
+      end
+    end
+
+    context 'with no overrides' do
+      before(:all) { generate_request_xml }
+
+      describe 'control block' do
+        it 'contains default values' do
+          %i(uniqueid dtdversion includewhitespace).each do |field_name|
+            expected_value = LegacyRequest::DEFAULTS[field_name].to_s
+            actual_value = get_value_from control_block_xml, field_name.to_s
+
+            expect(expected_value).to eq actual_value
+          end
+        end
+      end
+
+      describe 'operation block' do
+        it 'shows transaction default' do
+          expect(operation_block_xml.first.attributes['transaction'].value)
+            .to eq LegacyRequest::DEFAULTS[:transaction].to_s
+        end
+      end
+    end
+
+    context 'with overrides' do
+      describe 'control block' do
+        it 'shows overrides instead of defaults' do
+          overrides = {
+            uniqueid: 'uniqueid override',
+            dtdversion: 'dtdversion override',
+            includewhitespace: 'includewhitespace override'
+          }
+
+          generate_request_xml(overrides)
+
+          overrides.each do |field_name, field_value|
+            request_value = get_value_from control_block_xml, field_name.to_s
+
+            expect(request_value).to eq field_value
+          end
+        end
+      end
+
+      describe 'operations block' do
+        it 'shows overrides instead of defaults' do
+          transaction_override_value = 'Transaction Override'
+
+          generate_request_xml(transaction: transaction_override_value)
+
+          request_attribute = operation_block_xml.first.attributes['transaction']
+
+          expect(request_attribute.value).to eq transaction_override_value
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Contributor Self-Check:

* [x] My commits and messages [are solid](https://chris.beams.io/posts/git-commit/)
* [x] I have included tests that check success and failure
* [x] I have updated the README as appropriate

### Which GitHub Issues does this PR address?

#26

### What does this PR do?

At [Cloudsnap](https://cloudsnap.com), we inevitably hit a point where we needed to interact with any/all legacy endpoints. We were already using this gem for the non-legacy endpoints so it seemed logical to extend its functionality to support the legacy endpoints as well. This PR is that extension effort.

### How do I manually test this?

1. Launch the gem console
2. Instantiate a `LegacyRequest` instance with the proper authentication values
3. Create a legacy endpoint request with the proper `object_type` and `parameters`
4. Execute that request against a valid sandbox account

* See updated README for details on syntax when constructing a legacy request.

### Additional Comments

Note:
Parameter order for legacy endpoints is important and must match what is reflected in the developer docs as this is the order that is enforced on request.

I wanted to try and keep the feel of `Request` and `LegacyRequest` the same as much as possible when crafting a request so `LegacyRequest` still uses the `function_type` to trigger the no method error but does not add the function type to the constructed XML. Given this, it doesn't matter if the request uses `create`, `update`, `read` or any other supported function type, the resulting XML will be the same.

Hope others find this as useful as we have!
