### PR TITLE
try to add location to headers

### DIFF
--- a/lib/intacct_ruby/request.rb
+++ b/lib/intacct_ruby/request.rb
@@ -120,6 +120,7 @@ module IntacctRuby
           @request.userid    @opts[:userid]
           @request.companyid @opts[:companyid]
           @request.password  @opts[:user_password]
+          @request.locationid @opts[:locationid]
         end
       end
     end


### PR DESCRIPTION
[ES-120]-Intacct API session with location
Why:
without this modification, you cannot scope api calls to specific entities within Intact (everything will post to top level).
This change addresses the need by:
adding the optional location id to the authentication block.
Ticket
[ES-120]