### PR TITLE
ES-127-object-detail

### DIFF
--- a/lib/intacct_ruby/function.rb
+++ b/lib/intacct_ruby/function.rb
@@ -5,6 +5,7 @@ module IntacctRuby
   # a function to be sent to Intacct. Defined by a function type (e.g. :create),
   # an object type, (e.g. :customer), and parameters.
   class Function
+    attr_reader :detail
     ALLOWED_TYPES = %w(
       readByQuery
       read
@@ -21,6 +22,14 @@ module IntacctRuby
       @function_type = function_type.to_s
       @object_type = object_type.to_s
       @parameters = parameters
+      if @parameters.include?(:detail)
+        @detail = @parameters[:detail]
+        @parameters.delete(:detail)
+      end
+
+      if @parameters.include?(:name)
+        @parameters.delete(:name)
+      end
 
       validate_type!
     end
@@ -37,6 +46,18 @@ module IntacctRuby
           else
             xml << parameter_xml(@parameters)
           end
+        end
+      end
+
+      xml.target!
+    end
+
+    def special_to_xml
+      xml = Builder::XmlMarkup.new
+
+      xml.function controlid: controlid do
+        xml.tag!(@object_type, detail: @detail) do 
+          xml << parameter_xml(@parameters)
         end
       end
 

--- a/lib/intacct_ruby/request.rb
+++ b/lib/intacct_ruby/request.rb
@@ -129,7 +129,11 @@ module IntacctRuby
         authentication_block
         @request.content do
           functions.each do |function|
-            @request << function.to_xml
+            if function.detail.blank? 
+              @request << function.to_xml
+            else
+              @request << function.special_to_xml
+            end
           end
         end
       end


### PR DESCRIPTION
Why:

* previously unable to utilize the get object endpoint because it would fail when details were passed in.

This change addresses the need by:

* created a special xml request to handle requests that have a detail detail.  I know this is a really bad solution. open to suggestions for a better way because i love learning.

Ticket

* [ES-127]

**One more comment: I tried to update the to_xml method in the function class to handle the details if they were present, but for some reason could not get it to work there. I do not understand why.  I am kind of wondering if the function.to_xml in the build operations method is pointing to some other 'to_xml' function, though that seems unlikely.  Please enlighten me as to why updating that method did not work bc I am v curious 

