### PR TITLE
[L3-125] add_split_values_support

### DIFF
--- a/lib/intacct_ruby/function.rb
+++ b/lib/intacct_ruby/function.rb
@@ -10,6 +10,7 @@ module IntacctRuby
       read
       readByName
       readMore
+      readEntityDetails
       create
       update
       delete
@@ -53,14 +54,32 @@ module IntacctRuby
       "#{@function_type}-#{@object_type}-#{timestamp}"
     end
 
+    # SPLIT key is an array of implicit objects, if it goes through the normal recursive function the result is 
+    # combinded into one XML key. The check on 65 will ensure that each implicit object is converted with a SPLIT tag
     def parameter_xml(parameters_to_convert)
       xml = Builder::XmlMarkup.new
 
       parameters_to_convert.each do |key, value|
         parameter_key = key.to_s
 
-        xml.tag!(parameter_key) do
-          xml << parameter_value_as_xml(value)
+        if key == :SPLIT
+          xml << parameter_value_is_split(value)
+        else
+          xml.tag!(parameter_key) do
+            xml << parameter_value_as_xml(value)
+          end
+        end
+      end
+    
+      xml.target!
+    end
+
+    def parameter_value_is_split(array_of_hashes)
+      xml = Builder::XmlMarkup.new
+
+      array_of_hashes.each do |ob|
+        xml.tag!("SPLIT") do
+          xml << parameter_value_as_xml(ob)
         end
       end
 

--- a/lib/intacct_ruby/legacy_function.rb
+++ b/lib/intacct_ruby/legacy_function.rb
@@ -11,7 +11,8 @@ module IntacctRuby
       end unless attributes.empty?
 
       # Find the duplicate keys
-      duplicate = @parameters.deep_dup
+      # the `#send` is here so that we can keep this method private
+      duplicate = self.class.send(:deep_copy, @parameters)
       omitted_keys = []
 
       duplicate.each do |key, value|
@@ -52,6 +53,22 @@ module IntacctRuby
       end
 
       xml.target!
+    end
+
+    # Produces a deep copy of the given object
+    # similar to deep_dup in active_support
+    private_class_method def self.deep_copy(obj)
+      case obj
+      when Array
+        obj.map { |e| deep_copy(e) }
+      when Hash
+        obj.each_with_object({}) do |(k, v), copy|
+          copy[k] = deep_copy(v)
+          copy
+        end
+      else
+        obj
+      end
     end
 
   end


### PR DESCRIPTION
Why:

*Intacct requires the SPLIT to be unnamed hashes, which is not supported by the current methods. Right now, it combines the hashes into one.

This change addresses the need by:

*Added a check for :SPLIT keys and added a new method to handle this specific use-case.

Ticket

[L3-125]