### PR TITLE
CD-4503-increase-read-timeout-to-120

### DIFF
--- a/lib/intacct_ruby/api.rb
+++ b/lib/intacct_ruby/api.rb
@@ -25,6 +25,7 @@ module IntacctRuby
     def https_request(request, uri)
       @http_gateway ||= Net::HTTP.new uri.host, uri.port
       @http_gateway.use_ssl = true
+      @http_gateway.read_timeout = 120
       @http_gateway.request request
     end
   end


### PR DESCRIPTION
Why
Some requests to Intacct are timing out

Solution
Increase timeout from 60 to 120
